### PR TITLE
Separa instância de recursos da função main.

### DIFF
--- a/cmd/loganalytics/main.go
+++ b/cmd/loganalytics/main.go
@@ -3,30 +3,23 @@ package main
 import (
 	"fmt"
 
-	"github.com/WilliamDaniel/loganalytics/services/logparser"
-	"github.com/WilliamDaniel/loganalytics/services/logreader"
-	"github.com/WilliamDaniel/loganalytics/services/logreader/impllogreader"
 	"github.com/WilliamDaniel/loganalytics/services/logstorer"
-	"github.com/WilliamDaniel/loganalytics/services/logstorer/impllogstorer"
-	"github.com/WilliamDaniel/loganalytics/shared"
 )
 
 func main() {
-	logReaderAdapter := impllogreader.NewLogReaderAdapter("services/logreader/testdata/logs.txt")
-	logReaderService := logreader.NewService(logReaderAdapter)
+	logReaderService := getLogReaderService("services/logreader/testdata/logs.txt")
 	logFileReader, err := logReaderService.ReadFile()
 	if err != nil {
 		fmt.Println("error to read log file")
 	}
 
-	parserService := logparser.NewService(logFileReader)
+	parserService := getLogParserService(logFileReader)
 	parsedLogs, err := parserService.Parse()
 	if err != nil {
 		panic(err)
 	}
 
-	storageAdapter := impllogstorer.NewMemoryDbAdapter(shared.NewMemoryDb())
-	storageService := logstorer.NewService(storageAdapter)
+	storageService := getLogStorer()
 	logData := logstorer.LogData{
 		Logs: *parsedLogs,
 	}

--- a/cmd/loganalytics/resources.go
+++ b/cmd/loganalytics/resources.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"github.com/WilliamDaniel/loganalytics/services/logparser"
+	"github.com/WilliamDaniel/loganalytics/services/logreader"
+	"github.com/WilliamDaniel/loganalytics/services/logreader/impllogreader"
+	"github.com/WilliamDaniel/loganalytics/services/logstorer"
+	"github.com/WilliamDaniel/loganalytics/services/logstorer/impllogstorer"
+	"github.com/WilliamDaniel/loganalytics/shared"
+)
+
+var (
+	logReaderService logreader.Service
+	logParserService logparser.Service
+	logStorerService logstorer.Service
+)
+
+func getLogReaderService(sourcepath string) logreader.Service {
+	if logReaderService == nil {
+		logReaderService = logreader.NewService(
+			impllogreader.NewLogReaderAdapter(sourcepath),
+		)
+	}
+	return logReaderService
+}
+
+func getLogParserService(log *shared.LogFile) logparser.Service {
+	if logParserService == nil {
+		logParserService = logparser.NewService(log)
+	}
+	return logParserService
+}
+
+func getLogStorer() logstorer.Service {
+	if logStorerService == nil {
+		logStorerService = logstorer.NewService(
+			impllogstorer.NewMemoryDbAdapter(shared.NewMemoryDb()),
+		)
+	}
+	return logStorerService
+}

--- a/services/logreader/impllogreader/filereader_adapter.go
+++ b/services/logreader/impllogreader/filereader_adapter.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"os"
 
+	"github.com/WilliamDaniel/loganalytics/services/logreader"
 	"github.com/WilliamDaniel/loganalytics/shared"
 )
 
@@ -11,7 +12,7 @@ type LogReaderAdapter struct {
 	Filepath string
 }
 
-func NewLogReaderAdapter(Filepath string) LogReaderAdapter {
+func NewLogReaderAdapter(Filepath string) logreader.LogReaderGateway {
 	return LogReaderAdapter{
 		Filepath: Filepath,
 	}


### PR DESCRIPTION
Para organizar melhor o código, os recursos agora
ficam em resources e possui uma função responsável por instanciá-los como singleton.

A função main fica mais limpa e não se preocupa com os detalhes de instanciação de cada serviço ou adapter.